### PR TITLE
remove dntrademark group in api urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.phpunit.cache
 /node_modules
+/public/index.php
 /public/build
 /public/hot
 /public/storage

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ class User extends Authenticatable
      */
     protected $hidden = [
         'password',
+        'access_token',
         'remember_token',
     ];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,14 +22,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::prefix('v1')->namespace('v1')->group(function() {
-	Route::prefix('dntrademark')->group(function() {
-		Route::prefix('users')->group(function() {
-			Route::get('/',[ UserController::class, 'index' ])->middleware(EnsureApiKeyIsValid::class);
-		});
+	Route::prefix('users')->group(function() {
+		Route::get('/',[ UserController::class, 'index' ])->middleware(EnsureApiKeyIsValid::class);
+	});
 
-		Route::prefix('user')->group(function() {
-			Route::get('check',[ UserController::class, 'checkEmail' ])->middleware(EnsureApiKeyIsValid::class);
-			Route::post('save',[ UserController::class, 'storeUser' ])->middleware(EnsureApiKeyIsValid::class);
-		});
+	Route::prefix('user')->group(function() {
+		Route::get('check',[ UserController::class, 'checkEmail' ])->middleware(EnsureApiKeyIsValid::class);
+		Route::post('save',[ UserController::class, 'storeUser' ])->middleware(EnsureApiKeyIsValid::class);
 	});
 });


### PR DESCRIPTION
Route::prefix('v1')->namespace('v1')->group(function() {
	Route::prefix('users')->group(function() {
		Route::get('/',[ UserController::class, 'index' ])->middleware(EnsureApiKeyIsValid::class);
	});

	Route::prefix('user')->group(function() {
		Route::get('check',[ UserController::class, 'checkEmail' ])->middleware(EnsureApiKeyIsValid::class);
		Route::post('save',[ UserController::class, 'storeUser' ])->middleware(EnsureApiKeyIsValid::class);
	});
});
remove dntrademark group in api urls.